### PR TITLE
Move LLDPD data dir up one directory

### DIFF
--- a/mersive/entrypoint.sh
+++ b/mersive/entrypoint.sh
@@ -21,7 +21,7 @@ rm -rf *
              --with-sysroot=$TOOLCHAIN/sysroot \
              --prefix=/system \
              --sbindir=/system/bin \
-             --runstatedir=/data/data/lldpd \
+             --runstatedir=/data/lldpd \
              --with-privsep-user=root \
              --with-privsep-group=root \
              PKG_CONFIG=/bin/false \


### PR DESCRIPTION
Android uses /data/data to put APK specific data and the system tries to remove the lldpd directory we put in there.